### PR TITLE
:sparkles: Add many improvements

### DIFF
--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -11,7 +11,7 @@ tags = "go,lint"
 
 [pre-commit.commands.test]
 glob = "*.go"
-run = "go test ./..."
+run = "go test ./... -race"
 tags = "go,test"
 
 [prepare-commit-msg.commands.gitmoji]

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ dc:org: #dn: dc=org
   dc:example: #dn: dc=example,dc=org
     ou:group: #dn: ou=group,dc=example,dc=org
       cn:owner: &test #dn: cn=admin,ou=group,dc=example,dc=org      
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1000
         description: Organization owners
         memberUid: [alice]
       cn:dev: #dn: cn=dev,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1001
         description: Organization developers
         memberUid: [bob, charlie]
       cn:qa: #dn: cn=qa,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1002
         memberUid: [charlie, eve]
       cn:ok: #dn: cn=ok,ou=group,dc=example,dc=org
@@ -51,7 +51,7 @@ dc:org: #dn: dc=org
     c:global: #dn: c=global,dc=example,dc=org
       ou:people: #dn: ou=people,c=global,dc=example,dc=org
         cn:alice: #dn: cn=alice,ou=people,c=global,dc=example,dc=org
-          objectclass: [posixAccount, UserMail]
+          objectClass: [posixAccount, UserMail]
           .#acl:
             - !!ldap/acl:allow-on dc=org # allow alice to request everything
 
@@ -65,7 +65,7 @@ dc:org: #dn: dc=org
           usermail: alice@example.org
 
         cn:bob: #dn: cn=bob,ou=people,c=global,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow bob request only for user groups
 
@@ -78,7 +78,7 @@ dc:org: #dn: dc=org
     c:fr: #dn: c=fr,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:charlie: #dn: cn=charlie,ou=people,c=fr,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow charlie request for all groups...
             - !!ldap/acl:deny-on cn=admin,ou=group,dc=example,dc=org # ...but  to owner group
@@ -92,7 +92,7 @@ dc:org: #dn: dc=org
     c:uk: #dn: c=uk,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:eve: #dn: cn=eve,ou=people,c=uk,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           #NOTE: eve can't make any LDAP request (no !!ldap/bind:password field)
           uid: eve
           homeDirectory: /home/eve

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/puzpuzpuz/xsync/v3 v3.0.2
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611
+	golang.org/x/sync v0.1.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/xunleii/yaldap
 
 go 1.21
 
+// TODO: remove this once the following issue is resolved: https://github.com/jimlambrt/gldap/pull/58
+replace github.com/jimlambrt/gldap => github.com/xunleii/gldap v0.1.10
+
 require (
 	github.com/alecthomas/kong v0.8.1
 	github.com/go-asn1-ber/asn1-ber v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/xunleii/gldap v0.1.10 h1:/z/BGhttRhPgsNnYdxW/zaxsA1Rz71e8vtyXa1XZiG4=
+github.com/xunleii/gldap v0.1.10/go.mod h1:wQXacI2If7+C8z/IaTIf6Sbb+tqgFoqzujN2AaGzyck=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kong"
+	"github.com/xunleii/yaldap/pkg/utils"
 )
 
 type (
@@ -47,6 +48,8 @@ func (l *LogLevel) Decode(ctx *kong.DecodeContext) error {
 	}
 
 	switch level {
+	case "trace":
+		*l = LogLevel(utils.LevelTrace)
 	case "debug":
 		*l = LogLevel(slog.LevelDebug)
 	case "info":
@@ -56,7 +59,7 @@ func (l *LogLevel) Decode(ctx *kong.DecodeContext) error {
 	case "error":
 		*l = LogLevel(slog.LevelError)
 	default:
-		return fmt.Errorf("invalid level '%s': only debug, info, warn and error are allowed", level)
+		return fmt.Errorf("invalid level '%s': only trace, debug, info, warn and error are allowed", level)
 	}
 	return nil
 }

--- a/pkg/cmd/common_test.go
+++ b/pkg/cmd/common_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/assert"
 	"github.com/xunleii/yaldap/pkg/cmd"
+	"github.com/xunleii/yaldap/pkg/utils"
 )
 
 func TestLogger_Format(t *testing.T) {
@@ -26,6 +27,7 @@ func TestLogger_Format(t *testing.T) {
 
 func TestLogger_Level(t *testing.T) {
 	levels := map[string]slog.Level{
+		"trace": utils.LevelTrace,
 		"debug": slog.LevelDebug,
 		"info":  slog.LevelInfo,
 		"warn":  slog.LevelWarn,

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -23,7 +23,7 @@ import (
 type Server struct {
 	Base `embed:""`
 
-	AddrListen string `name:"addr-listen" help:"Address to listen on" default:":389"`
+	ListenAddr string `name:"listen-address" help:"Address to listen on" default:":389"`
 
 	Backend struct {
 		Name string `name:"name" help:"Backend which stores the data" enum:"yaml" required:"" placeholder:"BACKEND"`
@@ -72,7 +72,7 @@ func (s Server) Run(_ *kong.Context) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		return server.Run(s.AddrListen, gldap.WithTLSConfig(tlsConfig))
+		return server.Run(s.ListenAddr, gldap.WithTLSConfig(tlsConfig))
 	})
 
 	// Graceful shutdown.

--- a/pkg/cmd/server_test.go
+++ b/pkg/cmd/server_test.go
@@ -51,7 +51,7 @@ func TestServer_YAML_Simple(t *testing.T) {
 	)
 	defer client.Close()
 
-	err := client.Bind("cn=alice,ou=people,c=global,dc=example,dc=org", "alice")
+	err := client.Bind("cn=alice,ou=people,c=fr,dc=example,dc=org", "alice")
 	require.NoError(t, err)
 }
 
@@ -85,7 +85,7 @@ func TestServer_YAML_WithTLS(t *testing.T) {
 	)
 	defer client.Close()
 
-	err = client.Bind("cn=alice,ou=people,c=global,dc=example,dc=org", "alice")
+	err = client.Bind("cn=alice,ou=people,c=fr,dc=example,dc=org", "alice")
 	require.NoError(t, err)
 }
 
@@ -130,7 +130,7 @@ func TestServer_YAML_WithMutualTLS(t *testing.T) {
 	)
 	defer client.Close()
 
-	err = client.Bind("cn=alice,ou=people,c=global,dc=example,dc=org", "alice")
+	err = client.Bind("cn=alice,ou=people,c=fr,dc=example,dc=org", "alice")
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/server_test.go
+++ b/pkg/cmd/server_test.go
@@ -25,6 +25,7 @@ func TestServer_Defaults(t *testing.T) {
 	expected.Backend.URL = "file://../ldap/directory/yaml/fixtures/basic.yaml" //nolint:goconst
 	expected.TLS.Enable = false
 	expected.TLS.MutualTLS = false
+	expected.SessionTTL = 168 * time.Hour
 
 	os.Args = []string{"...", "--backend.name", "yaml", "--backend.url", "file://../ldap/directory/yaml/fixtures/basic.yaml"}
 	kong.Parse(&actual)
@@ -32,7 +33,7 @@ func TestServer_Defaults(t *testing.T) {
 }
 
 func TestServer_YAML_Simple(t *testing.T) {
-	server := Server{AddrListen: fmt.Sprintf("localhost:%d", freePort(t))}
+	server := Server{AddrListen: fmt.Sprintf("localhost:%d", freePort(t)), SessionTTL: 1 * time.Second}
 	server.Base.Log.Format = "test"
 	server.Backend.Name = "yaml"
 	server.Backend.URL = "file://../ldap/directory/yaml/fixtures/basic.yaml"

--- a/pkg/ldap/directory/common/types.go
+++ b/pkg/ldap/directory/common/types.go
@@ -97,7 +97,7 @@ func (obj Object) CanSearchOn(dn string) bool {
 func (obj Object) search(scope gldap.Scope, filter *ber.Packet) (objects []ldap.Object, err error) {
 	if match, err := filters.Match(&obj, filter); err != nil {
 		return nil, err
-	} else if match {
+	} else if match && scope != gldap.SingleLevel {
 		objects = append(objects, &obj)
 	}
 

--- a/pkg/ldap/directory/types.go
+++ b/pkg/ldap/directory/types.go
@@ -7,7 +7,9 @@ import (
 type (
 	// Directory contains all current LDAP object tree, accessible using a base DN.
 	Directory interface {
-		// BaseDN	returns the LDAP object represented by the given DN. If no object found, it returns nil.
+		// BaseDN returns the LDAP object represented by the given DN. If no object found,
+		// it returns nil.
+		// If the given DN is empty, it returns the root object.
 		BaseDN(dn string) Object
 	}
 

--- a/pkg/ldap/directory/yaml/README.md
+++ b/pkg/ldap/directory/yaml/README.md
@@ -56,17 +56,17 @@ dc:org: #dn: dc=org
   dc:example: #dn: dc=example,dc=org
     ou:group: #dn: ou=group,dc=example,dc=org
       cn:owner: &test #dn: cn=admin,ou=group,dc=example,dc=org      
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1000
         description: Organization owners
         memberUid: [alice]
       cn:dev: #dn: cn=dev,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1001
         description: Organization developers
         memberUid: [bob, charlie]
       cn:qa: #dn: cn=qa,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1002
         memberUid: [charlie, eve]
       cn:ok: #dn: cn=ok,ou=group,dc=example,dc=org
@@ -78,7 +78,7 @@ dc:org: #dn: dc=org
     c:global: #dn: c=global,dc=example,dc=org
       ou:people: #dn: ou=people,c=global,dc=example,dc=org
         cn:alice: #dn: cn=alice,ou=people,c=global,dc=example,dc=org
-          objectclass: [posixAccount, UserMail]
+          objectClass: [posixAccount, UserMail]
           .#acl:
             - !!ldap/acl:allow-on dc=org # allow alice to request everything
 
@@ -92,7 +92,7 @@ dc:org: #dn: dc=org
           usermail: alice@example.org
 
         cn:bob: #dn: cn=bob,ou=people,c=global,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow bob request only for user groups
 
@@ -105,7 +105,7 @@ dc:org: #dn: dc=org
     c:fr: #dn: c=fr,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:charlie: #dn: cn=charlie,ou=people,c=fr,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow charlie request for all groups...
             - !!ldap/acl:deny-on cn=admin,ou=group,dc=example,dc=org # ...but  to owner group
@@ -119,7 +119,7 @@ dc:org: #dn: dc=org
     c:uk: #dn: c=uk,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:eve: #dn: cn=eve,ou=people,c=uk,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           #NOTE: eve can't make any LDAP request (no !!ldap/bind:password field)
           uid: eve
           homeDirectory: /home/eve

--- a/pkg/ldap/directory/yaml/directory.go
+++ b/pkg/ldap/directory/yaml/directory.go
@@ -70,9 +70,9 @@ func NewDirectoryFromYAML(raw []byte) (ldap.Directory, error) {
 
 			switch value.Kind {
 			case yaml.MappingNode:
-				err = parseLDAPObject(directory.entries, key.Value, value)
+				err = parseLDAPObject(directory.entries, key, value)
 			case yaml.SequenceNode, yaml.ScalarNode:
-				err = parseLDAPAttribute(directory.entries, key.Value, value)
+				err = parseLDAPAttribute(directory.entries, key, value)
 			}
 
 			if err != nil {

--- a/pkg/ldap/directory/yaml/directory.go
+++ b/pkg/ldap/directory/yaml/directory.go
@@ -33,6 +33,7 @@ func NewDirectoryFromYAML(raw []byte) (ldap.Directory, error) {
 	directory := &directory{
 		entries: &common.Object{
 			ImplObject: common.ImplObject{
+				Attributes: ldap.Attributes{"objectClass": {"top", "yaLDAPRootDSE"}},
 				SubObjects: map[string]*common.Object{},
 			},
 		},
@@ -97,6 +98,10 @@ func indexDirectory(obj *common.Object, index map[string]*common.Object) {
 }
 
 func (d directory) BaseDN(dn string) ldap.Object {
+	if dn == "" {
+		return d.entries
+	}
+
 	obj, found := d.index[dn]
 	if !found {
 		return nil

--- a/pkg/ldap/directory/yaml/directory_fixtures_test.go
+++ b/pkg/ldap/directory/yaml/directory_fixtures_test.go
@@ -52,7 +52,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":          {"owner"},
-				"objectclass": {"posixGroup"},
+				"objectClass": {"posixGroup"},
 				"gidNumber":   {"1000"},
 				"description": {"Organization owners"},
 				"memberUid":   {"alice"},
@@ -67,7 +67,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":          {"dev"},
-				"objectclass": {"posixGroup"},
+				"objectClass": {"posixGroup"},
 				"gidNumber":   {"1001"},
 				"description": {"Organization developers"},
 				"memberUid":   {"bob", "charlie"},
@@ -82,7 +82,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":          {"qa"},
-				"objectclass": {"posixGroup"},
+				"objectClass": {"posixGroup"},
 				"gidNumber":   {"1002"},
 				"memberUid":   {"charlie", "eve"},
 			},
@@ -96,7 +96,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":          {"ok"},
-				"objectclass": {"posixGroup"},
+				"objectClass": {"posixGroup"},
 				"gidNumber":   {"1003"},
 				"description": {"Dummy group"},
 				"memberUid":   {"alice"},
@@ -133,7 +133,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":            {"alice"},
-				"objectclass":   {"posixAccount", "UserMail"},
+				"objectClass":   {"posixAccount", "UserMail"},
 				"description":   {"Main organization admin"},
 				"uid":           {"alice"},
 				"uidNumber":     {"1000"},
@@ -155,7 +155,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":            {"bob"},
-				"objectclass":   {"posixAccount"},
+				"objectClass":   {"posixAccount"},
 				"uid":           {"bob"},
 				"homeDirectory": {"/home/bob"},
 				"uidNumber":     {"1001"},
@@ -197,7 +197,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":            {"charlie"},
-				"objectclass":   {"posixAccount"},
+				"objectClass":   {"posixAccount"},
 				"uid":           {"charlie"},
 				"homeDirectory": {"/home/charlie"},
 				"uidNumber":     {"1100"},
@@ -242,7 +242,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":            {"eve"},
-				"objectclass":   {"posixAccount"},
+				"objectClass":   {"posixAccount"},
 				"uid":           {"eve"},
 				"homeDirectory": {"/home/eve"},
 				"uidNumber":     {"1003"},

--- a/pkg/ldap/directory/yaml/directory_fixtures_test.go
+++ b/pkg/ldap/directory/yaml/directory_fixtures_test.go
@@ -18,7 +18,8 @@ func TestFixture_Basic(t *testing.T) {
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"dc": {"org"},
+				"dc":          {"org"},
+				"objectClass": {"top", "domain"},
 			},
 			obj.Attributes(),
 		)
@@ -29,7 +30,8 @@ func TestFixture_Basic(t *testing.T) {
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"dc": {"example"},
+				"dc":          {"example"},
+				"objectClass": {"domain"},
 			},
 			obj.Attributes(),
 		)
@@ -40,7 +42,8 @@ func TestFixture_Basic(t *testing.T) {
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"ou": {"group"},
+				"ou":          {"group"},
+				"objectClass": {"top"},
 			},
 			obj.Attributes(),
 		)
@@ -106,34 +109,36 @@ func TestFixture_Basic(t *testing.T) {
 	})
 
 	t.Run("cn=admin,ou=group,dc=example,dc=org", func(t *testing.T) {
-		obj := directory.BaseDN("c=global,dc=example,dc=org")
+		obj := directory.BaseDN("c=fr,dc=example,dc=org")
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"c": {"global"},
+				"c":           {"fr"},
+				"objectClass": {"top", "country"},
 			},
 			obj.Attributes(),
 		)
 	})
 
-	t.Run("ou=people,c=global,dc=example,dc=org", func(t *testing.T) {
-		obj := directory.BaseDN("ou=people,c=global,dc=example,dc=org")
+	t.Run("ou=people,c=fr,dc=example,dc=org", func(t *testing.T) {
+		obj := directory.BaseDN("ou=people,c=fr,dc=example,dc=org")
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"ou": {"people"},
+				"ou":          {"people"},
+				"objectClass": {"top"},
 			},
 			obj.Attributes(),
 		)
 	})
 
-	t.Run("cn=alice,ou=people,c=global,dc=example,dc=org", func(t *testing.T) {
-		obj := directory.BaseDN("cn=alice,ou=people,c=global,dc=example,dc=org")
+	t.Run("cn=alice,ou=people,c=fr,dc=example,dc=org", func(t *testing.T) {
+		obj := directory.BaseDN("cn=alice,ou=people,c=fr,dc=example,dc=org")
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
 				"cn":            {"alice"},
-				"objectClass":   {"posixAccount", "UserMail"},
+				"objectClass":   {"posixAccount"},
 				"description":   {"Main organization admin"},
 				"uid":           {"alice"},
 				"uidNumber":     {"1000"},
@@ -149,8 +154,8 @@ func TestFixture_Basic(t *testing.T) {
 		assert.True(t, obj.CanSearchOn("dc=org"))
 	})
 
-	t.Run("cn=bob,ou=people,c=global,dc=example,dc=org", func(t *testing.T) {
-		obj := directory.BaseDN("cn=bob,ou=people,c=global,dc=example,dc=org")
+	t.Run("cn=bob,ou=people,c=fr,dc=example,dc=org", func(t *testing.T) {
+		obj := directory.BaseDN("cn=bob,ou=people,c=fr,dc=example,dc=org")
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
@@ -169,12 +174,13 @@ func TestFixture_Basic(t *testing.T) {
 		assert.True(t, obj.CanSearchOn("ou=group,dc=example,dc=org"))
 	})
 
-	t.Run("cn=charlie,ou=people,c=global,dc=example,dc=org", func(t *testing.T) {
+	t.Run("cn=charlie,ou=people,c=fr,dc=example,dc=org", func(t *testing.T) {
 		obj := directory.BaseDN("c=fr,dc=example,dc=org")
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"c": {"fr"},
+				"c":           {"fr"},
+				"objectClass": {"top", "country"},
 			},
 			obj.Attributes(),
 		)
@@ -185,14 +191,15 @@ func TestFixture_Basic(t *testing.T) {
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"ou": {"people"},
+				"ou":          {"people"},
+				"objectClass": {"top"},
 			},
 			obj.Attributes(),
 		)
 	})
 
-	t.Run("cn=charlie,ou=people,c=fr,dc=example,dc=org", func(t *testing.T) {
-		obj := directory.BaseDN("cn=charlie,ou=people,c=fr,dc=example,dc=org")
+	t.Run("cn=charlie,ou=people,c=de,dc=example,dc=org", func(t *testing.T) {
+		obj := directory.BaseDN("cn=charlie,ou=people,c=de,dc=example,dc=org")
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
@@ -209,9 +216,7 @@ func TestFixture_Basic(t *testing.T) {
 		assert.True(t, obj.Bind("charlie"))
 		assert.False(t, obj.CanSearchOn("dc=org"))
 		assert.True(t, obj.CanSearchOn("ou=group,dc=example,dc=org"))
-		x := obj.CanSearchOn("cn=admin,ou=group,dc=example,dc=org")
-		_ = x
-		assert.False(t, obj.CanSearchOn("cn=admin,ou=group,dc=example,dc=org"))
+		assert.False(t, obj.CanSearchOn("cn=owner,ou=group,dc=example,dc=org"))
 	})
 
 	t.Run("c=uk,dc=example,dc=org", func(t *testing.T) {
@@ -219,7 +224,8 @@ func TestFixture_Basic(t *testing.T) {
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"c": {"uk"},
+				"c":           {"uk"},
+				"objectClass": {"top", "country"},
 			},
 			obj.Attributes(),
 		)
@@ -230,7 +236,8 @@ func TestFixture_Basic(t *testing.T) {
 		require.NotNil(t, obj)
 		assert.Equal(t,
 			ldap.Attributes{
-				"ou": {"people"},
+				"ou":          {"people"},
+				"objectClass": {"top"},
 			},
 			obj.Attributes(),
 		)

--- a/pkg/ldap/directory/yaml/fixtures/basic.yaml
+++ b/pkg/ldap/directory/yaml/fixtures/basic.yaml
@@ -2,17 +2,17 @@ dc:org: #dn: dc=org
   dc:example: #dn: dc=example,dc=org
     ou:group: #dn: ou=group,dc=example,dc=org
       cn:owner: &test #dn: cn=admin,ou=group,dc=example,dc=org      
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1000
         description: Organization owners
         memberUid: [alice]
       cn:dev: #dn: cn=dev,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1001
         description: Organization developers
         memberUid: [bob, charlie]
       cn:qa: #dn: cn=qa,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1002
         memberUid: [charlie, eve]
       cn:ok: #dn: cn=ok,ou=group,dc=example,dc=org
@@ -24,7 +24,7 @@ dc:org: #dn: dc=org
     c:global: #dn: c=global,dc=example,dc=org
       ou:people: #dn: ou=people,c=global,dc=example,dc=org
         cn:alice: #dn: cn=alice,ou=people,c=global,dc=example,dc=org
-          objectclass: [posixAccount, UserMail]
+          objectClass: [posixAccount, UserMail]
           .#acl:
             - !!ldap/acl:allow-on dc=org # allow alice to request everything
 
@@ -38,7 +38,7 @@ dc:org: #dn: dc=org
           usermail: alice@example.org
 
         cn:bob: #dn: cn=bob,ou=people,c=global,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow bob request only for user groups
 
@@ -51,7 +51,7 @@ dc:org: #dn: dc=org
     c:fr: #dn: c=fr,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:charlie: #dn: cn=charlie,ou=people,c=fr,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow charlie request for all groups...
             - !!ldap/acl:deny-on cn=admin,ou=group,dc=example,dc=org # ...but  to owner group
@@ -65,7 +65,7 @@ dc:org: #dn: dc=org
     c:uk: #dn: c=uk,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:eve: #dn: cn=eve,ou=people,c=uk,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           #NOTE: eve can't make any LDAP request (no !!ldap/bind:password field)
           uid: eve
           homeDirectory: /home/eve

--- a/pkg/ldap/directory/yaml/fixtures/basic.yaml
+++ b/pkg/ldap/directory/yaml/fixtures/basic.yaml
@@ -1,7 +1,13 @@
 dc:org: #dn: dc=org
+  objectClass: [top, domain]
+
   dc:example: #dn: dc=example,dc=org
+    objectClass: [domain]
+
     ou:group: #dn: ou=group,dc=example,dc=org
-      cn:owner: &test #dn: cn=admin,ou=group,dc=example,dc=org      
+      objectClass: [top]
+
+      cn:owner: &test #dn: cn=owner,ou=group,dc=example,dc=org
         objectClass: posixGroup
         gidNumber: 1000
         description: Organization owners
@@ -21,10 +27,14 @@ dc:org: #dn: dc=org
         description: Dummy group
         # memberUid: [alice]
 
-    c:global: #dn: c=global,dc=example,dc=org
-      ou:people: #dn: ou=people,c=global,dc=example,dc=org
-        cn:alice: #dn: cn=alice,ou=people,c=global,dc=example,dc=org
-          objectClass: [posixAccount, UserMail]
+    c:fr: #dn: c=fr,dc=example,dc=org
+      objectClass: [top, country]
+
+      ou:people: #dn: ou=people,c=fr,dc=example,dc=org
+        objectClass: [top]
+
+        cn:alice: #dn: cn=alice,ou=people,c=fr,dc=example,dc=org
+          objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on dc=org # allow alice to request everything
 
@@ -37,7 +47,7 @@ dc:org: #dn: dc=org
           userPassword: !!ldap/bind:password alice
           usermail: alice@example.org
 
-        cn:bob: #dn: cn=bob,ou=people,c=global,dc=example,dc=org
+        cn:bob: #dn: cn=bob,ou=people,c=fr,dc=example,dc=org
           objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow bob request only for user groups
@@ -48,13 +58,17 @@ dc:org: #dn: dc=org
           gidNumber: 1001
           userPassword: !!ldap/bind:password  bob
 
-    c:fr: #dn: c=fr,dc=example,dc=org
-      ou:people: #dn: ou=people,c=fr,dc=example,dc=org
-        cn:charlie: #dn: cn=charlie,ou=people,c=fr,dc=example,dc=org
+    c:de: #dn: c=de,dc=example,dc=org
+      objectClass: [top, country]
+
+      ou:people: #dn: ou=people,c=de,dc=example,dc=org
+        objectClass: [top]
+
+        cn:charlie: #dn: cn=charlie,ou=people,c=de,dc=example,dc=org
           objectClass: posixAccount
           .#acl:
             - !!ldap/acl:allow-on ou=group,dc=example,dc=org # allow charlie request for all groups...
-            - !!ldap/acl:deny-on cn=admin,ou=group,dc=example,dc=org # ...but  to owner group
+            - !!ldap/acl:deny-on cn=owner,ou=group,dc=example,dc=org # ...but  to owner group
 
           uid: charlie
           homeDirectory: /home/charlie
@@ -63,7 +77,11 @@ dc:org: #dn: dc=org
           userPassword: !!ldap/bind:password charlie
 
     c:uk: #dn: c=uk,dc=example,dc=org
+      objectClass: [top, country]
+
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
+        objectClass: [top]
+
         cn:eve: #dn: cn=eve,ou=people,c=uk,dc=example,dc=org
           objectClass: posixAccount
           #NOTE: eve can't make any LDAP request (no !!ldap/bind:password field)

--- a/pkg/ldap/directory/yaml/fixtures/rfc.yaml
+++ b/pkg/ldap/directory/yaml/fixtures/rfc.yaml
@@ -2,24 +2,24 @@ dc:org: #dn: dc=org
   dc:example: #dn: dc=example,dc=org
     ou:group: #dn: ou=group,dc=example,dc=org
       cn:owner: #dn: cn=admin,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1000
         description: Organization owners
         memberUid: {{{ search '(gidNumber=1000)' | attribute uidNumber }}} #RFC(02): not yet implemented
       cn:dev: #dn: cn=dev,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1001
         description: Organization developers
         memberUid: {{{ search '(gidNumber=1001)' | attribute uidNumber }}} #RFC(02): not yet implemented
       cn:qa: #dn: cn=qa,ou=group,dc=example,dc=org
-        objectclass: posixGroup
+        objectClass: posixGroup
         gidNumber: 1002
         memberUid: {{{ search '(gidNumber=1002)' | attribute uidNumber }}} #RFC(02): not yet implemented
 
     c:global: #dn: c=global,dc=example,dc=org
       ou:people: #dn: ou=people,c=global,dc=example,dc=org
         cn:alice: #dn: cn=alice,ou=people,c=global,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#allowDN: !!ldap/acl:allow-on [dc=org] # allow alice to request everything
 
           uid: alice
@@ -30,7 +30,7 @@ dc:org: #dn: dc=org
           loginShell: /bin/bash
           userPassword: !!ldap/bind:password {{{ hscVaultSecret '/secret/ldap/users/global/alice#password' | passwordType 'base64' }}} #RFC(02): not yet implemented
         cn:bob: #dn: cn=bob,ou=people,c=global,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#allowDN: !!ldap/acl:allow-on [ou=group,dc=example,dc=org] # allow bob request only for user groups
 
           uid: bob
@@ -42,7 +42,7 @@ dc:org: #dn: dc=org
     c:fr: #dn: c=fr,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:charlie: #dn: cn=charlie,ou=people,c=fr,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
           .#allowDN: !!ldap/acl:allow-on [ou=group,dc=example,dc=org, c=fr,dc=example,dc=org] # allow charlie request only for user groups & fr peoples ...
           .#denyDN: !!ldap/acl:deny-on cn=admin,ou=group,dc=example,dc=org # ...but deny access to owner group
 
@@ -53,7 +53,7 @@ dc:org: #dn: dc=org
           userPassword: !!ldap/bind:password {{{ hscVaultSecret '/secret/ldap/users/global/bob#password' | passwordType 'base64' }}} #RFC(02): not yet implemented
         {{- range $id, $name := (hscVaultList 'secret/ldap/users/fr' | eval | without 'charlie') }} #RFC(02): not yet implemented
         cn:{{ $name }}: #dn: cn={{ $name }},ou=people,c=fr,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
 
           uid: charlie
           homeDirectory: /home/{{ $name }}
@@ -65,7 +65,7 @@ dc:org: #dn: dc=org
     c:uk: #dn: c=uk,dc=example,dc=org
       ou:people: #dn: ou=people,c=fr,dc=example,dc=org
         cn:eve: #dn: cn=eve,ou=people,c=uk,dc=example,dc=org
-          objectclass: posixAccount
+          objectClass: posixAccount
 
           #NOTE: eve can't make any LDAP request (no !!ldap/bind:password field)
           uid: eve
@@ -77,6 +77,6 @@ dc:org: #dn: dc=org
 ---
 !!ldap/schemas #RFC(03): not yet implemented
 
-objectclasses:
+objectClasses:
 - posixGroup:1.3.6.1.1.1.2.2:structural:Abstraction of a group of accounts
 - posixAccount:1.3.6.1.1.1.2.0:auxiliary:Abstraction of an account with POSIX attributes

--- a/pkg/ldap/directory/yaml/parse_test.go
+++ b/pkg/ldap/directory/yaml/parse_test.go
@@ -27,7 +27,7 @@ func TestParseLDAPObject_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{ImplObject: common.ImplObject{SubObjects: map[string]*common.Object{}}}
-	err = parseLDAPObject(obj, "go:test", node.Content[0])
+	err = parseLDAPObject(obj, &yaml.Node{Value: "go:test"}, node.Content[0])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj.SubObjects["go:test"].SubObjects)
 }
@@ -67,7 +67,7 @@ ou:people:
 	require.NoError(t, err)
 
 	obj := &common.Object{ImplObject: common.ImplObject{SubObjects: map[string]*common.Object{}}}
-	err = parseLDAPObject(obj, "go:test", node.Content[0])
+	err = parseLDAPObject(obj, &yaml.Node{Value: "go:test"}, node.Content[0])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj.SubObjects["go:test"].SubObjects)
 }
@@ -118,7 +118,7 @@ ou:people:
 	require.NoError(t, err)
 
 	obj := &common.Object{ImplObject: common.ImplObject{SubObjects: map[string]*common.Object{}}}
-	err = parseLDAPObject(obj, "go:test", node.Content[0])
+	err = parseLDAPObject(obj, &yaml.Node{Value: "go:test"}, node.Content[0])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj.SubObjects["go:test"].SubObjects)
 }
@@ -175,7 +175,7 @@ ou:people:
 	require.NoError(t, err)
 
 	obj := &common.Object{ImplObject: common.ImplObject{SubObjects: map[string]*common.Object{}}}
-	err = parseLDAPObject(obj, "go:test", node.Content[0])
+	err = parseLDAPObject(obj, &yaml.Node{Value: "go:test"}, node.Content[0])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj.SubObjects["go:test"].SubObjects)
 }
@@ -189,7 +189,7 @@ func TestParseLDAPObject_WithInvalidKey(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{ImplObject: common.ImplObject{SubObjects: map[string]*common.Object{}}}
-	err = parseLDAPObject(obj, "go:test", node.Content[0])
+	err = parseLDAPObject(obj, &yaml.Node{Value: "go:test"}, node.Content[0])
 	assert.EqualError(t, err, expectErr)
 }
 
@@ -207,7 +207,7 @@ ou:people:
 	require.NoError(t, err)
 
 	obj := &common.Object{ImplObject: common.ImplObject{SubObjects: map[string]*common.Object{}}}
-	err = parseLDAPObject(obj, "go:test", node.Content[0])
+	err = parseLDAPObject(obj, &yaml.Node{Value: "go:test"}, node.Content[0])
 	assert.EqualError(t, err, expectErr)
 }
 
@@ -225,7 +225,7 @@ func TestParseLDAPAttribute_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -243,7 +243,7 @@ func TestParseLDAPAttribute_WithNullValue(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -265,7 +265,7 @@ func TestParseLDAPAttribute_WithBindPassword(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -286,7 +286,7 @@ func TestParseLDAPAttribute_WithAllowedOn(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -308,7 +308,7 @@ func TestParseLDAPAttribute_WithMultipleAllowedOn(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -329,7 +329,7 @@ func TestParseLDAPAttribute_WithDeniedOn(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -351,7 +351,7 @@ func TestParseLDAPAttribute_WithMultipleDeniedOn(t *testing.T) {
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -383,7 +383,7 @@ authz:
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.NoError(t, err)
 	assert.Equal(t, expect, obj)
 }
@@ -401,6 +401,27 @@ invalid:
 	require.NoError(t, err)
 
 	obj := &common.Object{}
-	err = parseLDAPAttribute(obj, node.Content[0].Content[0].Value, node.Content[0].Content[1])
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
 	assert.EqualError(t, err, expectErr)
+}
+
+func TestParseLDAPAttribute_WithDupplicateAttribute(t *testing.T) {
+	rawAttr1 := `valid: true`
+	rawAttr2 := `Valid: number`
+
+	expectErr := "invalid LDAP YAML document at line 1, column 1: invalid attribute: 'Valid' is already defined (case-insensitive match with 'valid')"
+
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(rawAttr1), &node)
+	require.NoError(t, err)
+
+	obj := &common.Object{}
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
+	require.NoError(t, err)
+
+	err = yaml.Unmarshal([]byte(rawAttr2), &node)
+	require.NoError(t, err)
+
+	err = parseLDAPAttribute(obj, node.Content[0].Content[0], node.Content[0].Content[1])
+	require.EqualError(t, err, expectErr)
 }

--- a/pkg/ldap/directory/yaml/parse_test.go
+++ b/pkg/ldap/directory/yaml/parse_test.go
@@ -127,12 +127,12 @@ func TestParseLDAPObject_WithMergeField(t *testing.T) {
 	raw := `
 ou:people:
   uid:alice: &alice
-    objectclass: [posixAccount]
+    objectClass: [posixAccount]
     memberOf: [admin, user, h4ck3r]
     givenname: alice
   uid:bob:
     <<: *alice
-    objectclass: [UserMail]
+    objectClass: [UserMail]
     givenname: bob
 `
 	expect := map[string]*common.Object{
@@ -146,7 +146,7 @@ ou:people:
 							DN: "uid=alice,ou=people,go=test",
 							Attributes: ldap.Attributes{
 								"uid":         []string{"alice"},
-								"objectclass": []string{"posixAccount"},
+								"objectClass": []string{"posixAccount"},
 								"memberOf":    []string{"admin", "user", "h4ck3r"},
 								"givenname":   []string{"alice"},
 							},
@@ -158,7 +158,7 @@ ou:people:
 							DN: "uid=bob,ou=people,go=test",
 							Attributes: ldap.Attributes{
 								"uid":         []string{"bob"},
-								"objectclass": []string{"UserMail"},
+								"objectClass": []string{"UserMail"},
 								"memberOf":    []string{"admin", "user", "h4ck3r"},
 								"givenname":   []string{"bob"},
 							},

--- a/pkg/ldap/filters/comparator_resolvers.go
+++ b/pkg/ldap/filters/comparator_resolvers.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 	goldap "github.com/go-ldap/ldap/v3"
@@ -76,8 +77,11 @@ func compareResolver(fnc compareFnc, object ldap.Object, filter *ber.Packet) (bo
 		return false, fmt.Errorf("invalid condition: must be a valid string")
 	}
 
-	if attr, exists := object.Attributes()[attr]; exists {
-		return fnc(condition, attr), nil
+	for key, values := range object.Attributes() {
+		// NOTE: we need to compare the attribute name in a case-insensitive way.
+		if strings.EqualFold(key, attr) {
+			return fnc(condition, values), nil
+		}
 	}
 	return false, nil
 }

--- a/pkg/ldap/filters/comparator_resolvers_test.go
+++ b/pkg/ldap/filters/comparator_resolvers_test.go
@@ -47,6 +47,11 @@ func TestGreaterOrEqualResolver(t *testing.T) {
 			filter:   "(memberOf>=z)",
 			expected: assert.False,
 		},
+
+		{ // NOTE: case-insensitive attribute
+			filter:   "(uidnumber>=-1)",
+			expected: assert.True,
+		},
 	}
 
 	for _, tt := range tests {
@@ -122,6 +127,11 @@ func TestLessOrEqualResolver(t *testing.T) {
 		{
 			filter:   "(memberOf<= )",
 			expected: assert.False,
+		},
+
+		{ // NOTE: case-insensitive attribute
+			filter:   "(uidnumber<=1000)",
+			expected: assert.True,
 		},
 	}
 

--- a/pkg/ldap/filters/match_resolver_test.go
+++ b/pkg/ldap/filters/match_resolver_test.go
@@ -43,6 +43,11 @@ func TestApproxResolver(t *testing.T) {
 			filter:   "(memberOf~=398)",
 			expected: assert.True,
 		},
+
+		{ // NOTE: case-insensitive attribute
+			filter:   "(uidnumber~=1000)",
+			expected: assert.True,
+		},
 	}
 
 	for _, tt := range tests {
@@ -114,6 +119,11 @@ func TestEqualResolver(t *testing.T) {
 		{
 			filter:   "(memberOf=398)",
 			expected: assert.False,
+		},
+
+		{ // NOTE: case-insensitive attribute
+			filter:   "(uidnumber=1000)",
+			expected: assert.True,
 		},
 	}
 

--- a/pkg/ldap/filters/present_resolver.go
+++ b/pkg/ldap/filters/present_resolver.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"fmt"
+	"strings"
 
 	ber "github.com/go-asn1-ber/asn1-ber"
 	goldap "github.com/go-ldap/ldap/v3"
@@ -20,6 +21,11 @@ func PresentResolver(object ldap.Object, filter *ber.Packet) (bool, error) {
 		return false, &Error{goldap.FilterPresent, fmt.Errorf("invalid attribute: must be a valid non-empty string")}
 	}
 
-	_, exists := object.Attributes()[attr]
-	return exists, nil
+	for key, values := range object.Attributes() {
+		// NOTE: case-insensitive attribute
+		if strings.EqualFold(key, attr) && len(values) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/ldap/filters/present_resolver_test.go
+++ b/pkg/ldap/filters/present_resolver_test.go
@@ -23,6 +23,11 @@ func TestPresentResolver(t *testing.T) {
 			filter:   "(password=*)",
 			expected: assert.False,
 		},
+
+		{ // NOTE: case-insensitive attribute
+			filter:   "(memberof=*)",
+			expected: assert.True,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ldap/filters/substring_resolver.go
+++ b/pkg/ldap/filters/substring_resolver.go
@@ -52,8 +52,11 @@ func SubstringResolver(object ldap.Object, filter *ber.Packet) (bool, error) {
 		return false, &Error{goldap.FilterSubstrings, fmt.Errorf("internal error: %w", err)}
 	}
 
-	if attr, exists := object.Attributes()[attr]; exists {
-		return slices.IndexFunc(attr, func(s string) bool { return rx.MatchString(s) }) > -1, nil
+	for key, values := range object.Attributes() {
+		// NOTE: case-insensitive attribute
+		if strings.EqualFold(key, attr) && len(values) > 0 {
+			return slices.IndexFunc(values, func(s string) bool { return rx.MatchString(s) }) > -1, nil
+		}
 	}
 	return false, nil
 }

--- a/pkg/ldap/filters/substring_resolver_test.go
+++ b/pkg/ldap/filters/substring_resolver_test.go
@@ -47,6 +47,11 @@ func TestSubstringResolver(t *testing.T) {
 			filter:   "(memberOf=u*k*n)",
 			expected: assert.False,
 		},
+
+		{ // NOTE: case-insensitive attribute
+			filter:   "(memberof=ad*)",
+			expected: assert.True,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ldap/mux.go
+++ b/pkg/ldap/mux.go
@@ -1,11 +1,9 @@
 package ldap
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/jimlambrt/gldap"
 	"github.com/xunleii/yaldap/internal/ldap/auth"
@@ -23,10 +21,10 @@ type server struct {
 }
 
 // NewMux creates a new LDAP server.
-func NewMux(ctx context.Context, logger *slog.Logger, directory directory.Directory) *gldap.Mux {
+func NewMux(logger *slog.Logger, directory directory.Directory, sessions *auth.Sessions) *gldap.Mux {
 	server := &server{
 		logger:    logger,
-		sessions:  auth.NewSessions(ctx, time.Hour),
+		sessions:  sessions,
 		directory: directory,
 	}
 	mux, _ := gldap.NewMux()

--- a/pkg/ldap/mux_test.go
+++ b/pkg/ldap/mux_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/xunleii/yaldap/internal/ldap/auth"
 	"github.com/xunleii/yaldap/pkg/ldap"
 	yamldir "github.com/xunleii/yaldap/pkg/ldap/directory/yaml"
 )
@@ -33,6 +34,7 @@ type (
 
 func (suite *LDAPTestSuite) SetupSuite() {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sessions := auth.NewSessions(context.Background(), time.Minute)
 
 	directory, err := yamldir.NewDirectoryFromYAML([]byte(`
 dc:org:
@@ -65,7 +67,7 @@ dc:org:
 	suite.Server, err = gldap.NewServer()
 	suite.Require().NoError(err)
 
-	err = suite.Server.Router(ldap.NewMux(context.Background(), logger, directory))
+	err = suite.Server.Router(ldap.NewMux(logger, directory, sessions))
 	suite.Require().NoError(err)
 
 	go func() {

--- a/pkg/ldap/mux_test.go
+++ b/pkg/ldap/mux_test.go
@@ -35,10 +35,10 @@ func (suite *LDAPTestSuite) SetupSuite() {
 
 	directory, err := yamldir.NewDirectoryFromYAML([]byte(`
 dc:org:
-  objectclass: organization
+  objectClass: organization
   
   dc:example:
-    objectclass: organization
+    objectClass: organization
   
     ou:people:
       cn:alice:
@@ -46,18 +46,18 @@ dc:org:
           - !!ldap/acl:allow-on dc=example,dc=org
           - !!ldap/acl:deny-on cn=bob,ou=people,dc=example,dc=org
   
-        objectclass: person
+        objectClass: person
         userpassword: !!ldap/bind:password alice
   
       cn:bob:
-        objectclass: person
+        objectClass: person
         userpassword: !!ldap/bind:password ""
 
       cn:charlie:
-        objectclass: person
+        objectClass: person
   
   dc:example2:
-    objectclass: organization
+    objectClass: organization
 `))
 	suite.Require().NoError(err)
 
@@ -166,7 +166,7 @@ func (suite *LDAPTestSuite) TestMux_Search() {
 					DN: "cn=alice,ou=people,dc=example,dc=org",
 					Attributes: map[string][]string{
 						"cn":           {"alice"},
-						"objectclass":  {"person"},
+						"objectClass":  {"person"},
 						"userpassword": {"alice"},
 					},
 				},
@@ -176,7 +176,7 @@ func (suite *LDAPTestSuite) TestMux_Search() {
 	})
 
 	suite.T().Run("FindAllObjectclass", func(t *testing.T) {
-		req := goldap.NewSearchRequest("dc=org", goldap.ScopeWholeSubtree, 0, 0, 0, false, "(objectclass=*)", nil, nil)
+		req := goldap.NewSearchRequest("dc=org", goldap.ScopeWholeSubtree, 0, 0, 0, false, "(objectClass=*)", nil, nil)
 		res, err := conn.Search(req)
 		require.NoError(t, err)
 
@@ -186,14 +186,14 @@ func (suite *LDAPTestSuite) TestMux_Search() {
 					DN: "dc=example,dc=org",
 					Attributes: map[string][]string{
 						"dc":          {"example"},
-						"objectclass": {"organization"},
+						"objectClass": {"organization"},
 					},
 				},
 				{
 					DN: "cn=alice,ou=people,dc=example,dc=org",
 					Attributes: map[string][]string{
 						"cn":           {"alice"},
-						"objectclass":  {"person"},
+						"objectClass":  {"person"},
 						"userpassword": {"alice"},
 					},
 				},
@@ -201,7 +201,7 @@ func (suite *LDAPTestSuite) TestMux_Search() {
 					DN: "cn=charlie,ou=people,dc=example,dc=org",
 					Attributes: map[string][]string{
 						"cn":          {"charlie"},
-						"objectclass": {"person"},
+						"objectClass": {"person"},
 					},
 				},
 			},
@@ -226,7 +226,7 @@ func (suite *LDAPTestSuite) TestMux_Search() {
 					DN: "cn=alice,ou=people,dc=example,dc=org",
 					Attributes: map[string][]string{
 						"cn":           {"alice"},
-						"objectclass":  {"person"},
+						"objectClass":  {"person"},
 						"userpassword": {"alice"},
 					},
 				},
@@ -234,7 +234,7 @@ func (suite *LDAPTestSuite) TestMux_Search() {
 					DN: "cn=charlie,ou=people,dc=example,dc=org",
 					Attributes: map[string][]string{
 						"cn":          {"charlie"},
-						"objectclass": {"person"},
+						"objectClass": {"person"},
 					},
 				},
 			},

--- a/pkg/ldap/mux_test.go
+++ b/pkg/ldap/mux_test.go
@@ -1,6 +1,7 @@
 package ldap_test
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
@@ -64,7 +65,7 @@ dc:org:
 	suite.Server, err = gldap.NewServer()
 	suite.Require().NoError(err)
 
-	err = suite.Server.Router(ldap.NewMux(logger, directory))
+	err = suite.Server.Router(ldap.NewMux(context.Background(), logger, directory))
 	suite.Require().NoError(err)
 
 	go func() {

--- a/pkg/utils/gldap.go
+++ b/pkg/utils/gldap.go
@@ -1,0 +1,11 @@
+package utils
+
+import "github.com/jimlambrt/gldap"
+
+// LDAPScopes maps gldap.Scope to string for logging
+// purposes.
+var LDAPScopes = map[gldap.Scope]string{
+	gldap.BaseObject:   "base",
+	gldap.SingleLevel:  "one",
+	gldap.WholeSubtree: "sub",
+}


### PR DESCRIPTION
- :art: Rename objectclass to objectClass
- :loud_sound: Improve logs by addind Trace level
- :bug: (filters): LDAP attributes should be case-insensitive
- :sparkles: (mux): Return only requested filters
- :bug: Make yaLDAP more compliant with LDAP server
- :sparkles: Handle search requests on root DSE
- :sparkles: Handle gracefully shutdown
- :sparkles: Add a GC for all expired sessions
- :sparkles: Handle unbind LDAP operation
- :art: Extract Sessions creation from Mux builder
- :art: (cmd): Rename `addr-listen` flag to `listen-address`
- :bug: (auth): Fix race condition
